### PR TITLE
Update Spectral log and Coherence default files

### DIFF
--- a/ASoP-Coherence/ASoP_coherence_cmec_workflow.py
+++ b/ASoP-Coherence/ASoP_coherence_cmec_workflow.py
@@ -52,7 +52,8 @@ def get_dictionary(filename):
     """
     asop_dict = {}
     # Defaults for standard observational data
-    if 'default' in filename:
+    if 'CMORPH_V1.0.mjodiab_period_3hrmeans.precip.nc' in filename or \
+       'TRMM_3B42V7A.mjodiab_period_3hrmeans.precip.nc' in filename:
         asop_dict['infile']       = filename
         asop_dict['name']         = ''
         asop_dict['dt']           = 10800

--- a/ASoP-Spectral/ASoP1_Spectral/ASoP1_spectral_cmec_workflow.py
+++ b/ASoP-Spectral/ASoP1_Spectral/ASoP1_spectral_cmec_workflow.py
@@ -66,7 +66,7 @@ def main(model_dir, obs_dir, wk_dir, config_path=None, settings=None):
         print("Loading configuration file")
         with open (config_path,"r") as fname:
             settings=json.load(fname)["ASoP/Spectral"]
-        print("Settings from configuration file:\n",json.dumps(settings))
+        print("Settings from configuration file:\n",json.dumps(settings, indent=4))
     elif settings is None:
             settings={
                 "regions": {"default":[-10.0, 10.0, 60.0, 160.0]},
@@ -214,6 +214,7 @@ def making_histogram_files(filename_list,wk_dir):
     """
     desc = {}
     for fname in filename_list:
+        print("Loading cube for",fname)
         fname_tmp = os.path.basename(fname)
         hname = os.path.join(wk_dir,".".join(fname_tmp.split(".")[:-1])+"_hist.nc")
         ppndata1=make_hist_maps.read_data_cube(fname)

--- a/ASoP-Spectral/ASoP1_Spectral/make_hist_maps.py
+++ b/ASoP-Spectral/ASoP1_Spectral/make_hist_maps.py
@@ -164,7 +164,7 @@ def make_hist_ppn(ppn_cube,region=None):
             try:
                 print("  Calculating dt for conversion from accumulation to rate.")
                 dt = int((t2 - t1).total_seconds())
-                print("  dt =",str(dt))
+                print("  dt =",str(dt),"s")
             except AttributeError:
                 raise AttributeError('Time coordinate units not found in cube.')
             new_units = str(ppn_cube.units) + str(dt) + '-1 s-1'

--- a/ASoP-Spectral/ASoP1_Spectral/make_hist_maps.py
+++ b/ASoP-Spectral/ASoP1_Spectral/make_hist_maps.py
@@ -152,7 +152,7 @@ def make_hist_ppn(ppn_cube,region=None):
     """
 
 # Ensure precipitation data are in correct units for pbin definitions
-
+    print("  Original precipitation units are",str(ppn_cube.units))
     if (ppn_cube.units == '') or (ppn_cube.units is None):
         raise ValueError('Data cube has no units!')
     else:
@@ -162,19 +162,21 @@ def make_hist_ppn(ppn_cube,region=None):
             t1 = ppn_cube.coords('time')[0][0].cell(0).point
             t2 = ppn_cube.coords('time')[0][1].cell(0).point
             try:
+                print("  Calculating dt for conversion from accumulation to rate.")
                 dt = int((t2 - t1).total_seconds())
+                print("  dt =",dt)
             except AttributeError:
                 raise AttributeError('Time coordinate units not found in cube.')
             new_units = str(ppn_cube.units) + str(dt) + '-1 s-1'
             ppn_cube.units = new_units
             ppn_cube.convert_units('mm day-1')
-        if (str(ppn_cube.units)[0:1] == 'm'):
+        elif (str(ppn_cube.units)[0:1] == 'm'):
             ppn_cube.convert_units('mm day-1')
         elif (str(ppn_cube.units)[0:2] == 'kg') or (str(ppn_cube.units)[0:1] == 'g'):
             ppn_cube.convert_units('kg m-2 day-1')
         else:
             raise ValueError('Unrecognised units:',str(ppn_cube.units))
-
+    print("  Precipitation units converted to",(ppn_cube.units))
 # Extract region if required
 
     if region:

--- a/ASoP-Spectral/ASoP1_Spectral/make_hist_maps.py
+++ b/ASoP-Spectral/ASoP1_Spectral/make_hist_maps.py
@@ -176,7 +176,7 @@ def make_hist_ppn(ppn_cube,region=None):
             ppn_cube.convert_units('kg m-2 day-1')
         else:
             raise ValueError('Unrecognised units:',str(ppn_cube.units))
-    print("  Precipitation units converted to",(ppn_cube.units))
+    print("  Precipitation units converted to",str(ppn_cube.units))
 # Extract region if required
 
     if region:

--- a/ASoP-Spectral/ASoP1_Spectral/make_hist_maps.py
+++ b/ASoP-Spectral/ASoP1_Spectral/make_hist_maps.py
@@ -164,7 +164,7 @@ def make_hist_ppn(ppn_cube,region=None):
             try:
                 print("  Calculating dt for conversion from accumulation to rate.")
                 dt = int((t2 - t1).total_seconds())
-                print("  dt =",dt)
+                print("  dt =",str(dt))
             except AttributeError:
                 raise AttributeError('Time coordinate units not found in cube.')
             new_units = str(ppn_cube.units) + str(dt) + '-1 s-1'


### PR DESCRIPTION
This PR has two changes:
1) Add a few more print statements to make_hist_maps.py and the ASoP Spectral CMEC workflow so that users can see how the precipitation units are converted.
2) Add Nick's default files back into the Coherence CMEC workflow. These defaults can be updated later on, eg with something from obs4mips once a good dataset is identified.